### PR TITLE
Include stdlib header to allow compilation

### DIFF
--- a/random_walk_app/random_walk.cc
+++ b/random_walk_app/random_walk.cc
@@ -9,6 +9,7 @@
 //
 #include <iostream>
 #include <vector>
+#include <cstdlib>
 #include <time.h>
 #include <mpi.h>
 


### PR DESCRIPTION
rand, RAND_MAX, exit, atoi and srand are not defined if you do not include the stdlib header
