### PR TITLE
adds instructions for mpich2 plugin for starcluster

### DIFF
--- a/tutorials/launching-an-amazon-ec2-mpi-cluster/index.md
+++ b/tutorials/launching-an-amazon-ec2-mpi-cluster/index.md
@@ -113,6 +113,9 @@ To determine the cost of running your cluster, multiply the number of nodes by t
 
 > **Note** - Although t1.micro instances are the cheapest, they hang indefinitely for me when starting a cluster with StarCluster.
 
+### Enable mpich2 plugin for Starcluster
+Lastly, before launching Starcluster, enable the `mpich2` plugin for Starcluster by following [these steps](http://star.mit.edu/cluster/docs/0.93.3/plugins/mpich2.html).
+
 ## Starting, accessing, and stopping your cluster
 After your StarCluster is configured, type the following to start a cluster called "mpicluster." The default config uses "smallcluster" as the default cluster type:
 


### PR DESCRIPTION
Without the mpich2 plugin for Starcluster, running mpirun on the EC2 instance results in only a single process running separately on each node (world_size ends up being 1 for all nodes). See [here](http://stackoverflow.com/questions/24246733/mpi-on-an-aws-cluster/24308435) for a detailed error.
