### PR TITLE
Rename MPI_Rank function to TMPI_Rank

### DIFF
--- a/tutorials/performing-parallel-rank-with-mpi/code/makefile
+++ b/tutorials/performing-parallel-rank-with-mpi/code/makefile
@@ -3,11 +3,11 @@ MPICC?=mpicc
 
 all: ${EXECS}
 
-mpi_rank.o: mpi_rank.c
-	${MPICC} -c mpi_rank.c
+tmpi_rank.o: tmpi_rank.c
+	${MPICC} -c tmpi_rank.c
 
-random_rank: mpi_rank.o random_rank.c
-	${MPICC} -o random_rank random_rank.c mpi_rank.o
+random_rank: tmpi_rank.o random_rank.c
+	${MPICC} -o random_rank random_rank.c tmpi_rank.o
 
 clean:
 	rm -f ${EXECS} *.o

--- a/tutorials/performing-parallel-rank-with-mpi/code/random_rank.c
+++ b/tutorials/performing-parallel-rank-with-mpi/code/random_rank.c
@@ -4,12 +4,13 @@
 // free to modify it for your own use. Any distribution of the code must
 // either provide a link to www.mpitutorial.com or keep this header in tact.
 //
-// Runs the MPI_Rank function with random input.
+// Runs the TMPI_Rank function with random input.
 //
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpi.h>
-#include "mpi_rank.h"
+#include "tmpi_rank.h"
+#include <time.h>
 
 int main(int argc, char** argv) {
   MPI_Init(NULL, NULL);
@@ -24,7 +25,7 @@ int main(int argc, char** argv) {
 
   float rand_num = rand() / (float)RAND_MAX;
   int rank;
-  MPI_Rank(&rand_num, &rank, MPI_FLOAT, MPI_COMM_WORLD);
+  TMPI_Rank(&rand_num, &rank, MPI_FLOAT, MPI_COMM_WORLD);
   printf("Rank for %f on process %d - %d\n", rand_num, world_rank, rank);
 
   MPI_Barrier(MPI_COMM_WORLD);

--- a/tutorials/performing-parallel-rank-with-mpi/code/tmpi_rank.c
+++ b/tutorials/performing-parallel-rank-with-mpi/code/tmpi_rank.c
@@ -21,7 +21,7 @@ typedef struct {
   } number;
 } CommRankNumber;
 
-// Gathers numbers for MPI_Rank to process zero. Allocates enough space given the MPI datatype and
+// Gathers numbers for TMPI_Rank to process zero. Allocates enough space given the MPI datatype and
 // returns a void * buffer to process 0. It returns NULL to all other processes.
 void *gather_numbers_to_root(void *number, MPI_Datatype datatype, MPI_Comm comm) {
   int comm_rank, comm_size;
@@ -105,8 +105,8 @@ int *get_ranks(void *gathered_numbers, int gathered_number_count, MPI_Datatype d
 }
 
 // Gets the rank of the recv_data, which is of type datatype. The rank is returned
-// in send_data and is of type datatype.  
-int MPI_Rank(void *send_data, void *recv_data, MPI_Datatype datatype, MPI_Comm comm) {
+// in send_data and is of type datatype.
+int TMPI_Rank(void *send_data, void *recv_data, MPI_Datatype datatype, MPI_Comm comm) {
   // Check base cases first - Only support MPI_INT and MPI_FLOAT for this function.
   if (datatype != MPI_INT && datatype != MPI_FLOAT) {
     return MPI_ERR_TYPE;

--- a/tutorials/performing-parallel-rank-with-mpi/code/tmpi_rank.h
+++ b/tutorials/performing-parallel-rank-with-mpi/code/tmpi_rank.h
@@ -4,11 +4,11 @@
 // free to modify it for your own use. Any distribution of the code must
 // either provide a link to www.mpitutorial.com or keep this header in tact.
 //
-// Header file for MPI_Rank
+// Header file for TMPI_Rank
 //
 #ifndef __PARALLEL_RANK_H
 #define __PARALLEL_RANK_H 1
 
-int MPI_Rank(void *send_data, void *recv_data, MPI_Datatype datatype, MPI_Comm comm);
+int TMPI_Rank(void *send_data, void *recv_data, MPI_Datatype datatype, MPI_Comm comm);
 
 #endif


### PR DESCRIPTION
The MPI Standard forbids users from creating their own MPI_\* functions
to prevent confusion with functions in the standard itself. This commit
renames the MPI_Rank example to use the TMPI_ prefix to avoid confusion.

Don't worry. I fully intend to write a real contribution about Groups and Communicators. Think of this as a Hello World! contribution.
