### PR TITLE
Fix a typo in a link to /tutorials/

### DIFF
--- a/tutorials/mpi-broadcast-and-collective-communication/index.md
+++ b/tutorials/mpi-broadcast-and-collective-communication/index.md
@@ -156,4 +156,4 @@ Try running the code yourself and experiment at larger scales!
 ## Conclusions / up next
 Feel a little better about collective routines? In the [next MPI tutorial]({{ site.baseurl }}/mpi-scatter-gather-and-allgather/), I go over other essential collective communication routines - [gathering and scattering]({{ site.baseurl }}/mpi-scatter-gather-and-allgather/).
 
-For all lessons, go the the [MPI tutorials]({{ site.baseurl }}/tutorial/) page.
+For all lessons, go the the [MPI tutorials]({{ site.baseurl }}/tutorials/) page.


### PR DESCRIPTION
s/tutorial/tutorials/