### PR TITLE
[English version] Fix broken link from "MPI Broadcast and Collective Communication" to next tutorial 

### DIFF
--- a/tutorials/mpi-broadcast-and-collective-communication/index.md
+++ b/tutorials/mpi-broadcast-and-collective-communication/index.md
@@ -155,6 +155,6 @@ As you can see, there is no difference between the two implementations at two pr
 Try running the code yourself and experiment at larger scales!
 
 ## Conclusions / up next
-Feel a little better about collective routines? In the [next MPI tutorial]({{ site.baseurl }}/mpi-scatter-gather-and-allgather/), I go over other essential collective communication routines - [gathering and scattering]({{ site.baseurl }}/mpi-scatter-gather-and-allgather/).
+Feel a little better about collective routines? In the [next MPI tutorial]({{ site.baseurl }}/tutorials/mpi-scatter-gather-and-allgather/), I go over other essential collective communication routines - [gathering and scattering]({{ site.baseurl }}/tutorials/mpi-scatter-gather-and-allgather/).
 
 For all lessons, go the the [MPI tutorials]({{ site.baseurl }}/tutorials/) page.


### PR DESCRIPTION
`[next MPI tutorial]` and `[gathering and scattering]` both had a missing `/tutorials/..` folder in their path. This PR simply adds the missing folder to both links.

Regards.