### PR TITLE
Typo in run.py

### DIFF
--- a/tutorials/run.py
+++ b/tutorials/run.py
@@ -19,7 +19,7 @@ programs = {
     'probe': ('dynamic-receiving-with-mpi-probe-and-mpi-status', 2),
 
     # From the point-to-point-communication-application-random-walk tutorial
-    'random_walk': ('point-to-point-communication-application-random-walk', 2, ['100', '500', '20']),
+    'random_walk': ('point-to-point-communication-application-random-walk', 5, ['100', '500', '20']),
 
     # From the mpi-broadcast-and-collective-communication tutorial
     'my_bcast': ('mpi-broadcast-and-collective-communication', 4),


### PR DESCRIPTION
mpitutorial.com says that random_walk runs with 5 processes when using run.py but it runs with 2 instead of 5. I've changed the -n argument from 2 to 5.