### PR TITLE
Change old links to reflect new github organization

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,8 +20,8 @@ plugins:
 # Custom vars
 version:          1.0.0
 github:
-  repo:           https://github.com/wesleykendall/mpitutorial
-  code:           https://github.com/wesleykendall/mpitutorial/tree/gh-pages
+  repo:           https://github.com/mpitutorial/mpitutorial
+  code:           https://github.com/mpitutorial/mpitutorial/tree/gh-pages
 pages_list:
   Tutorials:    'tutorials'
   Recommended Books:    'recommended-books'

--- a/tutorials/launching-an-amazon-ec2-mpi-cluster/index.md
+++ b/tutorials/launching-an-amazon-ec2-mpi-cluster/index.md
@@ -136,7 +136,7 @@ Once you are logged into the cluster, your current working directory will be `/r
 While you are in one of the mounted home directories, go ahead and check out the MPI tutorial code from its GitHub repository. The code is used by every lesson on this site:
 
 ```
-git clone git://github.com/wesleykendall/mpitutorial.git
+git clone git://github.com/mpitutorial/mpitutorial.git
 ```
 
 After you feel comfortable with accessing your cluster, log out of it and stop your cluster:


### PR DESCRIPTION
@wesbland I updated mpitutorial to be under a github org. Although github will redirect old links, I went ahead and updated any remaining references to the old links. This is a pretty trivial change, so I will go ahead and merge